### PR TITLE
[ZP-950] iOS 13 video gallery

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -525,8 +525,24 @@ static NSString* toBase64(NSData* data) {
 
 - (CDVPluginResult*)resultForVideo:(NSDictionary*)info
 {
-    NSString* moviePath = [[info objectForKey:UIImagePickerControllerMediaURL] absoluteString];
-    return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:moviePath];
+    NSURL *url = [info objectForKey:UIImagePickerControllerMediaURL];
+
+    NSData *urlData = [NSData dataWithContentsOfURL:url];
+    NSArray   *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString  *documentsDirectory = [paths objectAtIndex:0];
+    NSString  *newfilePath = [NSString stringWithFormat:@"%@/%@", documentsDirectory, [url lastPathComponent]];
+
+     BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:newfilePath];
+     if (fileExists){
+         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
+     }
+
+     BOOL isWriteSuccess = [urlData writeToFile:newfilePath atomically:YES];
+     if (isWriteSuccess) {
+         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
+     } else {
+         return  [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Error Selcing Video"];
+     }
 }
 
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingMediaWithInfo:(NSDictionary*)info

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -528,21 +528,21 @@ static NSString* toBase64(NSData* data) {
     NSURL *url = [info objectForKey:UIImagePickerControllerMediaURL];
 
     NSData *urlData = [NSData dataWithContentsOfURL:url];
-    NSArray   *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString  *documentsDirectory = [paths objectAtIndex:0];
-    NSString  *newfilePath = [NSString stringWithFormat:@"%@/%@", documentsDirectory, [url lastPathComponent]];
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *documentsDirectory = [paths objectAtIndex:0];
+    NSString *newfilePath = [NSString stringWithFormat:@"%@/%@", documentsDirectory, [url lastPathComponent]];
 
-     BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:newfilePath];
-     if (fileExists){
-         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
-     }
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:newfilePath];
+    if (fileExists) {
+        return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
+    }
 
-     BOOL isWriteSuccess = [urlData writeToFile:newfilePath atomically:YES];
-     if (isWriteSuccess) {
-         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
-     } else {
-         return  [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Error selecting Video"];
-     }
+    BOOL isWriteSuccess = [urlData writeToFile:newfilePath atomically:YES];
+    if (isWriteSuccess) {
+        return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
+    } else {
+        return  [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Error selecting Video"];
+    }
 }
 
 - (void)imagePickerController:(UIImagePickerController*)picker didFinishPickingMediaWithInfo:(NSDictionary*)info

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -541,7 +541,7 @@ static NSString* toBase64(NSData* data) {
      if (isWriteSuccess) {
          return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:newfilePath];
      } else {
-         return  [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Error Selcing Video"];
+         return  [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Error selecting Video"];
      }
 }
 


### PR DESCRIPTION
the cause: The videos are being stored to in the temp directory for some reason and we look into the data/document direct to fine files that users selected from gallery/captured from camera 

Solution: 
Check if video file already exsits in data directory and if not, add it to the directory. 