### PR TITLE
[ZP-6506] Return content:// URI for videos from gallery on Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "6.0.1-dev",
+  "version": "6.0.1-dev-zp1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cordova-plugin-camera",
-  "version": "6.0.1-dev",
+  "name": "@zenput/cordova-plugin-camera",
+  "version": "6.0.1-dev-zp1",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="6.0.1-dev">
+    version="6.0.1-dev-zp1">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -719,7 +719,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             // If you ask for video or the selected file cannot be processed
             // there will be no attempt to resize any returned data.
             if (this.mediaType == VIDEO  || !isImageMimeTypeProcessable(mimeTypeOfGalleryFile)) {
-                this.callbackContext.success(finalLocation);
+                this.callbackContext.success(uriString);
             } else {
 
                 // This is a special case to just return the path as no scaling,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Calling `camera.getPicture()` was returning a `file://` URL for videos from the gallery. This breaks on Android 10/11+ because [Scoped Storage](https://pednekarshashank33.medium.com/android-10s-scoped-storage-image-picker-gallery-camera-d3dcca427bbf) prevents us from accessing those paths directly. In order to target API level 30 (required by Google as of November), we need to comply with Scoped Storage.

```js
Camera.getPicture(
    function(file) {
        // file was a string starting with 'file://'
    },
    function(error) {
        // ...
    },
    {
        destinationType: Camera.DestinationType.FILE_URI,
        sourceType: Camera.PictureSourceType.PHOTOLIBRARY,
        mediaType: $f.mobile.cordova.camera.MediaType.VIDEO
    }
);
```

[See Cordova Docs for more context](https://cordova.apache.org/docs/en/10.x/reference/cordova-plugin-camera/).

### Description
<!-- Describe your changes in detail -->

This addresses the above problem by returning a `content://` URI from `getPicture()` for videos instead of a `file://` one. There may be a more complete fix that addresses this for pictures, but internally at Zenput, we use other plugins for selecting/taking pictures.

### Testing
<!-- Please describe in detail how you tested your changes. -->

When combined with https://github.com/zenput/zenput/pull/9687, the user should be able to select and upload a video from the gallery (existing behavior).

### Checklist

- [ ] ~~I've run the tests to see all new and existing tests pass~~
  - Tests are failing upstream, but I've tested manually
- [ ] ~~I added automated test coverage as appropriate for this change~~
  - Due to the above failures and because I couldn't find any existing tests for this, adding new ones felt out of scope.
