### PR TITLE
[ZP-8706] Support Cordova 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenput/cordova-plugin-camera",
-  "version": "6.0.1-dev-zp1",
+  "version": "6.0.1-dev-zp2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cordova-plugin-camera",
+  "name": "@zenput/cordova-plugin-camera",
   "version": "6.0.1-dev-zp1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenput/cordova-plugin-camera",
-  "version": "6.0.1-dev-zp1",
+  "version": "6.0.1-dev-zp2",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {
-    "id": "cordova-plugin-camera",
+    "id": "@zenput/cordova-plugin-camera",
     "platforms": [
       "android",
       "ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="@zenput/cordova-plugin-camera"
-    version="6.0.1-dev-zp1">
+    version="6.0.1-dev-zp2">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-plugin-camera"
+    id="@zenput/cordova-plugin-camera"
     version="6.0.1-dev-zp1">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>


### PR DESCRIPTION
This updates our forked plugin naming to work with Cordova 11 by using the `@zenput/` scoping everywhere.